### PR TITLE
Update version to @1

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If the installation ID is empty, the action will try to use the first available 
 ```
   - name: my-app-install tokens
     id: my-app
-    uses: LexisNexis-GHA-Public/action-github-app-auth@1.1.0
+    uses: LexisNexis-GHA-Public/action-github-app-auth@1
     with:
       app_id: ${{ secrets.APP_ID }}
       base64_pem_key: ${{ secrets.BASE64_PEM_KEY }}
@@ -58,7 +58,7 @@ If the installation ID is empty, the action will try to use the first available 
 ```
   - name: my-app-install tokens
     id: my-app
-    uses: LexisNexis-GHA-Public/action-github-app-auth@1.1.0
+    uses: LexisNexis-GHA-Public/action-github-app-auth@1
     with:
       app_id: ${{ secrets.APP_ID }}
       base64_pem_key: ${{ secrets.BASE64_PEM_KEY }}


### PR DESCRIPTION
Updated version in your docs to be @1 to be similar to most public actions.  This way non-api-breaking changes will be picked up automatically.

it does require you to track the version (tag) with the real one 1.x.x and the logical one 1.

Thoughts?